### PR TITLE
おすすめアイテムの画像投稿

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 
 .DS_Store
 /vendor/bundle
+
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -34,12 +34,15 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 gem "devise"
 gem "devise-i18n"
 
 gem "rails-i18n"
+
+gem "carrierwave"
+gem "mini_magick"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (1.3.4)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
+      ssrf_filter (~> 1.0, < 1.1.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -111,10 +116,19 @@ GEM
       devise (>= 4.9.0)
     drb (2.2.1)
     erubi (1.13.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.1)
       rdoc (>= 4.0.0)
@@ -137,6 +151,11 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1001)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
@@ -254,6 +273,9 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     securerandom (0.3.1)
     selenium-webdriver (4.25.0)
@@ -269,6 +291,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.0.8)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -309,12 +332,15 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  carrierwave
   cssbundling-rails
   debug
   devise
   devise-i18n
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  mini_magick
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1, >= 7.2.1.1)

--- a/app/controllers/recommends_controller.rb
+++ b/app/controllers/recommends_controller.rb
@@ -7,11 +7,11 @@ class RecommendsController < ApplicationController
 
   def by_place
     @place = params[:place]
-    @recommends = Recommend.includes(:user).where(place: @place)
+    @recommends = Recommend.where(place: @place)
   end
 
   def show
-    @recommend = Recommend.includes(:user).find(params[:id])
+    @recommend = Recommend.find(params[:id])
   end
 
   def new
@@ -51,6 +51,6 @@ class RecommendsController < ApplicationController
   private
 
   def recommend_params
-    params.require(:recommend).permit(:place, :item, :body)
+    params.require(:recommend).permit(:place, :item, :body, :item_image, :item_image_cache)
   end
 end

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -4,4 +4,6 @@ class Recommend < ApplicationRecord
   validates :body, length: { maximum: 65_535 }
 
   belongs_to :user
+
+  mount_uploader :item_image, ItemImageUploader
 end

--- a/app/uploaders/item_image_uploader.rb
+++ b/app/uploaders/item_image_uploader.rb
@@ -32,12 +32,12 @@ class ItemImageUploader < CarrierWave::Uploader::Base
   # version :thumb do
   #   process resize_to_fit: [50, 50]
   # end
-  process resize_to_fit: [400,400]
+  process resize_to_fit: [ 400, 400 ]
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_whitelist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg gif png]
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/item_image_uploader.rb
+++ b/app/uploaders/item_image_uploader.rb
@@ -1,0 +1,60 @@
+class ItemImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+  process resize_to_fit: [400,400]
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format "webp"
+      img
+    end
+  end
+
+  def filename
+    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
+  end
+end

--- a/app/views/recommends/_form.html.erb
+++ b/app/views/recommends/_form.html.erb
@@ -11,6 +11,10 @@
     <%= f.label :body, class: "block text-sm font-medium mb-2" %>
     <%= f.text_area :body, placeholder: "購入場所、価格帯、おすすめポイントなど", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs", rows: 5 %>
   </div>
+  <div>
+    <%= f.file_field :item_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full max-w-xs mt-4 mb-4", accept: 'image/*' %>
+    <%= f.hidden_field :item_image_cache %>
+  </div>
   <div class="flex mt-4 justify-end">
     <%= f.submit submit_label, class: "btn btn-primary w-full mt-4" %>
   </div>

--- a/app/views/recommends/show.html.erb
+++ b/app/views/recommends/show.html.erb
@@ -1,16 +1,21 @@
 <div class="container mx-auto max-w-md m-12">
   <div class="item-card bg-slate-50 shadow rounded-lg p-4 m-2">
-      <div class="text-lg mb-4"><%= "#{@recommend.item}" %></div>
-      <div class="mb-6"><%= "by #{@recommend.user.name}" %></div>
-      <div class="mt-6 text-gray-700">
-        <%= simple_format(@recommend.body) %>
-      </div>
-      <div class="flex justify-end">
-        <% if user_signed_in? && current_user.own?(@recommend) %>
-          <%= link_to edit_recommend_path(@recommend), id: "button-edit-#{@recommend.id}", class: "p-2" do %>
-            <i class="fa-solid fa-pen"></i>
-          <% end %>
+    <div class="text-lg mb-4"><%= "#{@recommend.item}" %></div>
+    <div class="mb-6"><%= "by #{@recommend.user.name}" %></div>
+    <div class="mt-6 text-gray-700">
+      <%= simple_format(@recommend.body) %>
+    </div>
+
+    <% if @recommend.item_image? %>
+      <%= image_tag @recommend.item_image_url, class: "w-52 h-38 rounded shadow mt-8" %>
+    <% end %>
+
+    <div class="flex justify-end">
+      <% if user_signed_in? && current_user.own?(@recommend) %>
+        <%= link_to edit_recommend_path(@recommend), id: "button-edit-#{@recommend.id}", class: "p-2" do %>
+          <i class="fa-solid fa-pen"></i>
         <% end %>
-      </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flash_background_color(message_type) %> max-w-60 mx-auto text-center text-sm border rounded-full mt-8 py-2">
+  <div class="<%= flash_background_color(message_type) %> max-w-96 mx-auto text-center text-sm border rounded-full mt-8 py-2" style="white-space: nowrap;">
     <%= message %>
   </div>
 <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,3 +13,4 @@ ja:
         place: 持って行く場所
         item: 持って行くもの
         body: コメント
+        item_image: 持って行くものの写真

--- a/db/migrate/20241024223111_add_item_image_to_recommends.rb
+++ b/db/migrate/20241024223111_add_item_image_to_recommends.rb
@@ -1,0 +1,5 @@
+class AddItemImageToRecommends < ActiveRecord::Migration[7.2]
+  def change
+    add_column :recommends, :item_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_24_060617) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_24_223111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_24_060617) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "item_image"
     t.index ["user_id"], name: "index_recommends_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
おすすめアイテムの画像投稿
### 内容
- gem "image_processing", "carrierwave", "mini_magick"を追加
- item_image_uploaderを生成
- 画像を.webpに変換するよう設定
- 作成画面に画像投稿ボタンを追加し、詳細画面に画像を表示
- ローカルでアップロードした画像を.gitignoreに追加
- フラッシュメッセージを改行しないよう設定