### PR TITLE
オリジナルのアイテム削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,6 +45,13 @@ class ItemsController < ApplicationController
     redirect_to item_list_path(@item_list)
   end
 
+  def destroy_original_item
+    item_list = ItemList.find(params[:item_list_id])
+    original_item = item_list.original_items.find(params[:id])
+    original_item.destroy!
+    redirect_to new_item_list_item_path(item_list), status: :see_other
+  end
+
   private
 
   def set_item_list

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -8,6 +8,7 @@
           <div class="flex items-center gap-2">
             <%= check_box_tag "item_list[original_item_ids][]", item.id, item.selected, class: "checkbox checkbox-primary checkbox-sm" %>
             <%= item.name %>
+            <%= link_to "✕", item_list_item_destroy_original_item_path(@item_list, item.id, id: item.id), data: { turbo_method: :delete }, class: "p-2 btn btn-ghost btn-circle btn-sm" %>
           </div>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,9 @@ Rails.application.routes.draw do
   end
 
   resources :item_lists do
-    resources :items, only: %i[new create update] do
+    resources :items, only: %i[new create update destroy] do
       post :new_original_item, on: :collection
+      delete "destroy_original_item/:id", action: :destroy_original_item, as: :destroy_original_item
     end
   end
 


### PR DESCRIPTION
## 概要
オリジナルのアイテム削除
### 内容
- ユーザーが追加したオリジナルのアイテムを削除できるよう設定
- ルーティング、コントローラーを追加
- 「リストを編集」ボタンで表示される画面に削除ボタンを追加