### PR TITLE
画像投稿（持ち物リスト）

### DIFF
--- a/app/controllers/item_lists_controller.rb
+++ b/app/controllers/item_lists_controller.rb
@@ -72,5 +72,5 @@ class ItemListsController < ApplicationController
 
   def item_list_params
     params.require(:item_list).permit(:name, :cover_image, :cover_image_cache, original_item_ids: [], default_item_ids: [])
-  end  
+  end
 end

--- a/app/controllers/item_lists_controller.rb
+++ b/app/controllers/item_lists_controller.rb
@@ -71,6 +71,6 @@ class ItemListsController < ApplicationController
   private
 
   def item_list_params
-    params.require(:item_list).permit(:name, original_item_ids: [], default_item_ids: [])
-  end
+    params.require(:item_list).permit(:name, :cover_image, :cover_image_cache, original_item_ids: [], default_item_ids: [])
+  end  
 end

--- a/app/javascript/modals.js
+++ b/app/javascript/modals.js
@@ -7,6 +7,11 @@ export function openRenameModal(id) {
   document.getElementById(`menuModal_${id}`).close();
   document.getElementById(`renameModal_${id}`).showModal();
 }
+// カバー画像をアップロード
+export function openCoverImageModal(id) {
+  document.getElementById(`menuModal_${id}`).close();
+  document.getElementById(`coverImageModal_${id}`).showModal();
+}
 // リスト削除
 export function openDeleteModal(id) {
   document.getElementById(`menuModal_${id}`).close();
@@ -24,6 +29,7 @@ export function openItemQuantityModal(id) {
 
 window.openMenuModal = openMenuModal;
 window.openRenameModal = openRenameModal;
+window.openCoverImageModal = openCoverImageModal;
 window.openDeleteModal = openDeleteModal;
 window.openItemModal = openItemModal;
 window.openItemQuantityModal = openItemQuantityModal;

--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -8,4 +8,6 @@ class ItemList < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :user, presence: true
+
+  mount_uploader :cover_image, CoverImageUploader
 end

--- a/app/uploaders/cover_image_uploader.rb
+++ b/app/uploaders/cover_image_uploader.rb
@@ -40,7 +40,7 @@ class CoverImageUploader < CarrierWave::Uploader::Base
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_whitelist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg gif png]
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/cover_image_uploader.rb
+++ b/app/uploaders/cover_image_uploader.rb
@@ -1,0 +1,63 @@
+class CoverImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+  process resize_to_fit: [ 400, 400 ]
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format "webp"
+      img
+    end
+  end
+
+  def filename
+    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
+  end
+end

--- a/app/views/item_lists/_item_list.html.erb
+++ b/app/views/item_lists/_item_list.html.erb
@@ -1,55 +1,7 @@
 <div class="flex p-4">
   <div>
     <%= link_to item_lists_path(item_list), id: "item_list-id-#{item_list.id}" do %>
-      <div class="card bg-base-100 w-52 h-38 shadow">
-        <div class="card-body flex flex-col items-center">
-          <h2 class="card-title text-base font-medium text-center">
-            <%= link_to item_list.name, item_list_path(item_list) %>
-          </h2>
-
-          <i class="fa-solid fa-ellipsis absolute top-4 right-6" onclick="openMenuModal(<%= item_list.id %>)"></i>
-
-          <dialog id="menuModal_<%= item_list.id %>" class="modal">
-            <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
-              <div class="modal-action flex flex-col mx-auto w-full space-y-6">
-                <button class="btn btn-primary" onclick="openRenameModal(<%= item_list.id %>)">リスト名を変更</button>
-                <button class="btn btn-bg-base-300" onclick="openDeleteModal(<%= item_list.id %>)">リストを削除</button>
-                <button class="btn btn-ghost" onclick="document.getElementById('menuModal_<%= item_list.id %>').close()">キャンセル</button>
-              </div>
-            </div>
-          </dialog>
-
-          <dialog id="renameModal_<%= item_list.id %>" class="modal">
-            <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
-              <%= form_with model: item_list, url: item_list_path(item_list), method: :patch, local: true do |f| %>
-                <label class="form-control w-full max-w-xs">
-                  <input type="text" name="item_list[name]" class="input input-bordered w-full max-w-xs" value="<%= item_list.name %>" required />
-                </label>
-                <div class="modal-action mt-4">
-                  <%= f.submit '決定', class: "btn btn-primary w-full" %>
-                </div>
-              <% end %>
-              <div class="modal-action">
-                <button class="btn btn-ghost" onclick="document.getElementById('renameModal_<%= item_list.id %>').close()">キャンセル</button>
-              </div>
-            </div>
-          </dialog>
-
-          <dialog id="deleteModal_<%= item_list.id %>" class="modal">
-            <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
-              <h3 class="font-semibold text-base text-accent">リストを削除しますか？</h3>
-              <div class="modal-action mt-4">
-                <form method="post" action="<%= item_list_path(item_list) %>">
-                  <%= hidden_field_tag :_method, 'delete' %>
-                  <button class="btn btn-accent" type="submit">削除する</button>
-                </form>
-                <button class="btn" onclick="document.getElementById('deleteModal_<%= item_list.id %>').close()">キャンセル</button>
-              </div>
-            </div>
-          </dialog>
-
-        </div>
-      </div>
+      <%= render 'item_list_card', item_list: item_list %>
     <% end %>
   </div>
 </div>

--- a/app/views/item_lists/_item_list_card.html.erb
+++ b/app/views/item_lists/_item_list_card.html.erb
@@ -1,0 +1,22 @@
+<% if item_list.cover_image.present? %>
+  <div class="card bg-base-100 image-full w-64 aspect-[16/9] shadow-xl relative">
+    <%= image_tag item_list.cover_image.url, class: "object-cover rounded-2xl opacity-50 w-64 aspect-[16/9]" %>
+    <div class="card-body flex flex-col justify-center items-center h-full relative z-10">
+      <h2 class="card-title text-base font-medium text-center">
+        <%= link_to item_list.name, item_list_path(item_list) %>
+      </h2>
+      <i class="fa-solid fa-ellipsis absolute top-4 right-6" onclick="openMenuModal(<%= item_list.id %>)"></i>
+      <%= render 'item_list_modal', item_list: item_list %>
+    </div>
+  </div>
+<% else %>
+  <div class="card bg-base-100 w-64 aspect-[16/9] shadow">
+    <div class="card-body flex flex-col justify-center items-center">
+      <h2 class="card-title text-base font-medium text-center">
+        <%= link_to item_list.name, item_list_path(item_list) %>
+      </h2>
+      <i class="fa-solid fa-ellipsis absolute top-4 right-6" onclick="openMenuModal(<%= item_list.id %>)"></i>
+      <%= render 'item_list_modal', item_list: item_list %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/item_lists/_item_list_modal.html.erb
+++ b/app/views/item_lists/_item_list_modal.html.erb
@@ -1,0 +1,56 @@
+<dialog id="menuModal_<%= item_list.id %>" class="modal">
+  <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
+    <div class="modal-action flex flex-col mx-auto w-full space-y-6">
+      <button class="btn btn-primary" onclick="openRenameModal(<%= item_list.id %>)">リスト名を変更</button>
+      <button class="btn btn-primary" onclick="openCoverImageModal(<%= item_list.id %>)">カバー画像をアップロード</button>
+      <button class="btn btn-bg-base-300" onclick="openDeleteModal(<%= item_list.id %>)">リストを削除</button>
+      <button class="btn btn-ghost" onclick="document.getElementById('menuModal_<%= item_list.id %>').close()">キャンセル</button>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="renameModal_<%= item_list.id %>" class="modal">
+  <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
+    <%= form_with model: item_list, url: item_list_path(item_list), method: :patch, local: true do |f| %>
+      <label class="form-control w-full max-w-xs">
+        <input type="text" name="item_list[name]" class="input input-bordered w-full max-w-xs" value="<%= item_list.name %>" required />
+      </label>
+      <div class="modal-action mt-4">
+        <%= f.submit '決定', class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+    <div class="modal-action">
+      <button class="btn btn-ghost" onclick="document.getElementById('renameModal_<%= item_list.id %>').close()">キャンセル</button>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="coverImageModal_<%= item_list.id %>" class="modal">
+  <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
+    <%= form_with model: item_list, url: item_list_path(item_list), method: :patch, local: true do |f| %>
+      <div>
+        <%= f.file_field :cover_image, class: "file-input file-input-bordered file-input-primary file-input-sm w-full mt-2 mb-4", accept: 'image/*' %>
+        <%= f.hidden_field :cover_image_cache %>
+      </div>
+      <div class="flex mt-4 justify-end">
+        <%= f.submit t('item_lists.new.submit_label'), class: "btn btn-primary w-full mt-4" %>
+      </div>
+    <% end %>
+    <div class="modal-action">
+      <button class="btn btn-ghost" onclick="document.getElementById('coverImageModal_<%= item_list.id %>').close()">キャンセル</button>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="deleteModal_<%= item_list.id %>" class="modal">
+  <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
+    <h3 class="font-semibold text-base text-accent">リストを削除しますか？</h3>
+    <div class="modal-action mt-4">
+      <form method="post" action="<%= item_list_path(item_list) %>">
+        <%= hidden_field_tag :_method, 'delete' %>
+        <button class="btn btn-accent" type="submit">削除する</button>
+      </form>
+      <button class="btn" onclick="document.getElementById('deleteModal_<%= item_list.id %>').close()">キャンセル</button>
+    </div>
+  </div>
+</dialog>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,4 +15,3 @@ ja:
         item: 持って行くもの
         body: コメント
         item_image: 写真
-

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,3 +31,5 @@ ja:
   item_lists:
     index:
       title: 持ち物リスト
+    new:
+      submit_label: "アップロード"

--- a/db/migrate/20241109132755_add_cover_image_to_item_lists.rb
+++ b/db/migrate/20241109132755_add_cover_image_to_item_lists.rb
@@ -1,0 +1,5 @@
+class AddCoverImageToItemLists < ActiveRecord::Migration[7.2]
+  def change
+    add_column :item_lists, :cover_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_07_232031) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_09_132755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_232031) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cover_image"
     t.index ["name"], name: "index_item_lists_on_name", unique: true
     t.index ["user_id"], name: "index_item_lists_on_user_id"
   end


### PR DESCRIPTION
- [ ] cover_image_uploaderを生成
- [ ] ストロングパラメータを追加
- [ ] 持ち物リスト一覧のモーダル内に画像投稿ボタンを追加
- [ ] カバー画像がアップロードされた場合は、カードの背景にカバー画像を表示
- [ ] カードとモーダルをパーシャルファイルに切り出し
- [ ] i18n対応
