### PR TITLE
かばんの中身一覧

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,3 @@ https://www.figma.com/design/8f474smVjo7Xg5O3HH0DZq/All-Ready?node-id=0-1&t=96ja
 
 ## ER図
 https://dbdiagram.io/d/All-Ready-670be10097a66db9a3cf1d05
-<img src="https://i.gyazo.com/058ae1f4bc62c7ac7582f2af260302ca.png" width="500px" />

--- a/app/controllers/bag_contents_controller.rb
+++ b/app/controllers/bag_contents_controller.rb
@@ -1,0 +1,31 @@
+class BagContentsController < ApplicationController
+  def index
+    @bag_contents = current_user.bag_contents.includes(:user).order(created_at: :desc)
+  end
+
+  def new
+    @bag_content = current_user.bag_contents.new
+  end
+
+  def create
+    @item_list = ItemList.find(params[:item_list_id])
+
+    if current_user.bag_contents.exists?(item_list_id: @item_list.id)
+      redirect_to item_list_path(@item_list), alert: "この持ち物リストは既に共有されています"
+    else
+      @bag_content = current_user.bag_contents.new(bag_content_params.merge(item_list: @item_list))
+
+      if @bag_content.save
+        redirect_to item_list_bag_contents_path(@item_list), notice: "持ち物リストを共有しました"
+      else
+        render :new, alert: "持ち物リストを共有できませんでした"
+      end
+    end
+  end
+
+  private
+
+  def bag_content_params
+    params.require(:bag_content).permit(:item_list_id, :body)
+  end
+end

--- a/app/javascript/modals.js
+++ b/app/javascript/modals.js
@@ -12,6 +12,11 @@ export function openCoverImageModal(id) {
   document.getElementById(`menuModal_${id}`).close();
   document.getElementById(`coverImageModal_${id}`).showModal();
 }
+// リスト共有
+export function openShareModal(id) {
+  document.getElementById(`menuModal_${id}`).close();
+  document.getElementById(`shareModal_${id}`).showModal();
+}
 // リスト削除
 export function openDeleteModal(id) {
   document.getElementById(`menuModal_${id}`).close();
@@ -30,6 +35,7 @@ export function openItemQuantityModal(id) {
 window.openMenuModal = openMenuModal;
 window.openRenameModal = openRenameModal;
 window.openCoverImageModal = openCoverImageModal;
+window.openShareModal = openShareModal;
 window.openDeleteModal = openDeleteModal;
 window.openItemModal = openItemModal;
 window.openItemQuantityModal = openItemQuantityModal;

--- a/app/models/bag_content.rb
+++ b/app/models/bag_content.rb
@@ -1,0 +1,6 @@
+class BagContent < ApplicationRecord
+  belongs_to :item_list
+  belongs_to :user
+
+  validates :item_list_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -5,6 +5,7 @@ class ItemList < ApplicationRecord
   has_many :item_list_default_items, dependent: :destroy
   has_many :default_items, through: :item_list_default_items
   has_many :item_statuses, dependent: :destroy
+  has_many :bag_contents, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :user, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :recommends, dependent: :destroy
   has_many :item_lists, dependent: :destroy
   has_many :original_items, dependent: :destroy
+  has_many :bag_contents, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/bag_contents/_bag_content.html.erb
+++ b/app/views/bag_contents/_bag_content.html.erb
@@ -1,0 +1,18 @@
+<div class="card bg-base-100 w-64 shadow rounded-lg m-4">
+  <% if bag_content.item_list.cover_image.present? %>
+    <div class="card image-full relative">
+      <%= image_tag bag_content.item_list.cover_image.url, class: "object-cover rounded-lg opacity-50 w-64 aspect-[16/9]" %>
+      <div class="card-body flex flex-col justify-center items-center h-full relative z-10">
+        <h2 class="card-title text-base font-medium text-center">
+          <%= link_to bag_content.item_list.name, item_list_path(bag_content.item_list) %>
+        </h2>
+      </div>
+    </div>
+  <% else %>
+    <div class="card-body flex flex-col justify-center items-center">
+      <h2 class="card-title text-base font-medium text-center">
+        <%= link_to bag_content.item_list.name, item_list_path(bag_content.item_list) %>
+      </h2>
+    </div>
+  <% end %>
+</div>

--- a/app/views/bag_contents/index.html.erb
+++ b/app/views/bag_contents/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container mx-auto pt-3 py-24">
+  <h1 class="text-lg font-medium mb-6"><%= t('.title') %></h1>
+
+  <div class="flex flex-wrap justify-center md:justify-start">
+    <% if @bag_contents.present? %>
+      <%= render @bag_contents %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/item_lists/_item_list_card.html.erb
+++ b/app/views/item_lists/_item_list_card.html.erb
@@ -1,6 +1,6 @@
 <% if item_list.cover_image.present? %>
-  <div class="card bg-base-100 image-full w-64 aspect-[16/9] shadow-xl relative">
-    <%= image_tag item_list.cover_image.url, class: "object-cover rounded-2xl opacity-50 w-64 aspect-[16/9]" %>
+  <div class="card bg-base-100 image-full w-64 aspect-[16/9] shadow rounded-lg relative">
+    <%= image_tag item_list.cover_image.url, class: "object-cover rounded-lg opacity-50 w-64 aspect-[16/9]" %>
     <div class="card-body flex flex-col justify-center items-center h-full relative z-10">
       <h2 class="card-title text-base font-medium text-center">
         <%= link_to item_list.name, item_list_path(item_list) %>
@@ -10,7 +10,7 @@
     </div>
   </div>
 <% else %>
-  <div class="card bg-base-100 w-64 aspect-[16/9] shadow">
+  <div class="card bg-base-100 w-64 aspect-[16/9] shadow rounded-lg">
     <div class="card-body flex flex-col justify-center items-center">
       <h2 class="card-title text-base font-medium text-center">
         <%= link_to item_list.name, item_list_path(item_list) %>

--- a/app/views/item_lists/_item_list_modal.html.erb
+++ b/app/views/item_lists/_item_list_modal.html.erb
@@ -3,6 +3,11 @@
     <div class="modal-action flex flex-col mx-auto w-full space-y-6">
       <button class="btn btn-primary" onclick="openRenameModal(<%= item_list.id %>)">リスト名を変更</button>
       <button class="btn btn-primary" onclick="openCoverImageModal(<%= item_list.id %>)">カバー画像をアップロード</button>
+      <% unless current_user.bag_contents.exists?(item_list_id: item_list.id) %>
+        <button class="btn btn-primary" onclick="openShareModal(<%= item_list.id %>)">リストを共有</button>
+      <% else %>
+        <button class="btn btn-bg-base-300">リストを共有中</button>
+      <% end %>
       <button class="btn btn-bg-base-300" onclick="openDeleteModal(<%= item_list.id %>)">リストを削除</button>
       <button class="btn btn-ghost" onclick="document.getElementById('menuModal_<%= item_list.id %>').close()">キャンセル</button>
     </div>
@@ -38,6 +43,27 @@
     <% end %>
     <div class="modal-action">
       <button class="btn btn-ghost" onclick="document.getElementById('coverImageModal_<%= item_list.id %>').close()">キャンセル</button>
+    </div>
+  </div>
+</dialog>
+
+<dialog id="shareModal_<%= item_list.id %>" class="modal">
+  <div class="modal-box bg-slate-50 w-96 mx-auto flex flex-col items-center py-12">
+    <h2 class="text-base font-medium">
+      <%= link_to item_list.name, item_list_path(item_list) %>
+    </h2>
+    <%= form_with model: BagContent.new, url: item_list_bag_contents_path(item_list), local: true do |f| %>
+      <%= f.hidden_field :item_list_id, value: item_list.id %>
+      <div>
+        <%= f.label :body, class: "block text-sm font-medium mb-2" %>
+        <%= f.text_area :body, placeholder: "こだわりポイント、おすすめのアイテムなど", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs", rows: 5 %>
+      </div>
+      <div class="modal-action mt-4">
+        <%= f.submit 'かばんの中身を共有', class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+    <div class="modal-action">
+      <button class="btn btn-ghost" onclick="document.getElementById('shareModal_<%= item_list.id %>').close()">キャンセル</button>
     </div>
   </div>
 </dialog>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,3 +15,5 @@ ja:
         item: 持って行くもの
         body: コメント
         item_image: 写真
+      bag_content:
+        body: コメント

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,3 +33,6 @@ ja:
       title: 持ち物リスト
     new:
       submit_label: "アップロード"
+  bag_contents:
+    index:
+      title: みんなのかばんの中身

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,9 +16,10 @@ Rails.application.routes.draw do
       delete "destroy_original_item/:id", action: :destroy_original_item, as: :destroy_original_item
     end
     resources :quantities, only: %i[index edit update]
+    resources :bag_contents, only: %i[index new create]
   end
 
-  resources :item_statuses, only: [ :update ] do
+  resources :item_statuses, only: %i[update] do
     patch :toggle, on: :member
   end
 

--- a/db/migrate/20241110093725_create_bag_contents.rb
+++ b/db/migrate/20241110093725_create_bag_contents.rb
@@ -1,0 +1,10 @@
+class CreateBagContents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bag_contents do |t|
+      t.references :item_list, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+      t.text :body
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_09_132755) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_10_093725) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bag_contents", force: :cascade do |t|
+    t.bigint "item_list_id", null: false
+    t.bigint "user_id", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_list_id"], name: "index_bag_contents_on_item_list_id"
+    t.index ["user_id"], name: "index_bag_contents_on_user_id"
+  end
 
   create_table "default_items", force: :cascade do |t|
     t.string "name", null: false
@@ -69,6 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_09_132755) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.integer "item_list_id"
     t.index ["user_id"], name: "index_original_items_on_user_id"
   end
 
@@ -96,6 +107,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_09_132755) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bag_contents", "item_lists"
+  add_foreign_key "bag_contents", "users"
   add_foreign_key "item_list_default_items", "default_items"
   add_foreign_key "item_list_default_items", "item_lists"
   add_foreign_key "item_list_original_items", "item_lists"
@@ -104,6 +117,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_09_132755) do
   add_foreign_key "item_statuses", "default_items"
   add_foreign_key "item_statuses", "item_lists"
   add_foreign_key "item_statuses", "original_items"
+  add_foreign_key "original_items", "item_lists"
   add_foreign_key "original_items", "users"
   add_foreign_key "recommends", "users"
 end


### PR DESCRIPTION
## 概要
かばんの中身一覧
### 内容
- [ ] BagContentモデル、bag_contentsテーブルを生成
- [ ] アソシエーション、バリデーションを追加
- [ ] ルーティング、コントローラー、ビューを追加
- [ ] 持ち物リスト一覧のモーダル内にかばんの中身共有ボタンを追加
- [ ] モーダルに投稿フォームを追加
- [ ] 共有された持ち物リストをかばんの中身一覧に表示
- [ ] 1つの持ち物リストを1回のみ共有できるよう設定
- [ ] i18n対応