### PR TITLE
エラーハンドリング

### DIFF
--- a/app/controllers/bag_contents_controller.rb
+++ b/app/controllers/bag_contents_controller.rb
@@ -26,6 +26,11 @@ class BagContentsController < ApplicationController
   def create
     @bag_content = @item_list.bag_contents.find_by(user: current_user)
 
+    if @item_list.original_items.empty? && @item_list.default_items.empty?
+      redirect_to item_list_path(@item_list), alert: "空の持ち物リストは共有できません"
+      return
+    end
+
     if @bag_content.nil?
       @bag_content = BagContent.new(bag_content_params)
     end
@@ -36,9 +41,9 @@ class BagContentsController < ApplicationController
       @bag_content = current_user.bag_contents.new(bag_content_params.merge(item_list: @item_list))
 
       if @bag_content.save_with_tags(tag_name: params.dig(:bag_content, :tag_name).split(",").uniq)
-        redirect_to item_list_bag_contents_path(@item_list), notice: "かばんの中身を共有しました"
+        redirect_to item_list_bag_contents_path(@item_list), notice: "持ち物リストを共有しました"
       else
-        render :new, alert: "かばんの中身を共有できませんでした"
+        render :new, alert: "持ち物リストを共有できませんでした"
       end
     end
   end
@@ -50,9 +55,9 @@ class BagContentsController < ApplicationController
   def update
     @bag_content = current_user.bag_contents.find(params[:id])
     if @bag_content.save_with_tags(tag_name: params.dig(:bag_content, :tag_name).split(",").uniq)
-      redirect_to bag_contents_path(@bag_content), notice: "かばんの中身を更新しました"
+      redirect_to bag_contents_path(@bag_content), notice: "投稿を更新しました"
     else
-      flash.now[:alert] = "かばんの中身を更新できませんでした"
+      flash.now[:alert] = "投稿を更新できませんでした"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/item_lists_controller.rb
+++ b/app/controllers/item_lists_controller.rb
@@ -1,6 +1,7 @@
 class ItemListsController < ApplicationController
   def index
     @item_lists = current_user.item_lists.includes(:user).order(created_at: :asc)
+    @bag_contents = BagContent.all
   end
 
   def show
@@ -57,7 +58,7 @@ class ItemListsController < ApplicationController
           end
         end
       end
-      redirect_to item_list_path(@item_list), notice: t("defaults.flash_message.updated", item: ItemList.model_name.human)
+      redirect_to item_lists_path, notice: t("defaults.flash_message.updated", item: ItemList.model_name.human)
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,19 +10,20 @@ class ItemsController < ApplicationController
 
   def create
     @item_list = ItemList.find(params[:item_list_id])
-    existing_item = OriginalItem.find_by(name: original_item_params[:name], user: current_user)
 
-    new_original_item = existing_item || OriginalItem.new(original_item_params.merge(user: current_user))
+    new_original_item = OriginalItem.new(original_item_params.merge(user: current_user))
 
     if new_original_item.save
-      ItemListOriginalItem.find_or_create_by(item_list: @item_list, original_item: new_original_item)
+      item_list_original_item = ItemListOriginalItem.find_or_create_by(item_list: @item_list, original_item: new_original_item)
+      item_status = ItemStatus.find_or_create_by(item_list: @item_list, original_item: new_original_item)
+
       redirect_to new_item_list_item_path(@item_list)
     else
       render :new
     end
   end
 
-  def update
+  def update  
     if params[:original_item_ids].present?
       @item_list.original_items.update_all(selected: false)
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  def update  
+  def update
     if params[:original_item_ids].present?
       @item_list.original_items.update_all(selected: false)
 

--- a/app/controllers/quantities_controller.rb
+++ b/app/controllers/quantities_controller.rb
@@ -3,6 +3,10 @@ class QuantitiesController < ApplicationController
 
   def index
     @item_statuses = @item_list.item_statuses.where(selected: true)
+    if @item_statuses.empty?
+      flash[:alert] = "持ち物リストにアイテムを追加してください"
+      redirect_to item_list_path(@item_list)
+    end
   end
 
   def edit

--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -7,7 +7,7 @@ class ItemList < ApplicationRecord
   has_many :item_statuses, dependent: :destroy
   has_many :bag_contents, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :name, presence: true
   validates :user, presence: true
 
   mount_uploader :cover_image, CoverImageUploader

--- a/app/views/item_lists/_item_list_modal.html.erb
+++ b/app/views/item_lists/_item_list_modal.html.erb
@@ -6,7 +6,11 @@
       <% unless current_user.bag_contents.exists?(item_list_id: item_list.id) %>
         <button class="btn btn-primary" onclick="openShareModal(<%= item_list.id %>)">リストを共有</button>
       <% else %>
-        <button class="btn btn-bg-base-300">リストを共有中</button>
+        <% @bag_contents.each do |bag_content| %>
+          <% if bag_content.item_list_id == item_list.id %>
+            <%= link_to "リストを共有中", item_list_bag_content_path(item_list.id, bag_content.id), class: "btn btn-bg-base-300", onclick: "document.getElementById('menuModal_#{item_list.id}').close();" %>
+          <% end %>
+        <% end %>
       <% end %>
       <button class="btn btn-bg-base-300" onclick="openDeleteModal(<%= item_list.id %>)">リストを削除</button>
       <button class="btn btn-ghost" onclick="document.getElementById('menuModal_<%= item_list.id %>').close()">キャンセル</button>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -9,11 +9,12 @@
       <div class="flex gap-8">
           <div class="flex">
             <div class="container bg-base-100 p-6 rounded-lg shadow flex-1">
-              <div class="flex flex-col items-start mt-6 gap-4">
+              <div class="flex flex-col items-start gap-4">
                 <h3 class="text-sm">既存のアイテム</h3>
                 <% @default_items.each do |item| %>
                   <div class="flex items-center gap-2">
                     <% status = item.item_statuses.find_by(item_list_id: @item_list.id) %>
+                    <%= hidden_field_tag "item_list[default_item_ids][]", nil %>
                     <%= check_box_tag "item_list[default_item_ids][]", item.id, status&.selected, class: "checkbox checkbox-primary checkbox-sm" %>
                     <%= item.name %>
                   </div>
@@ -36,6 +37,7 @@
         <% end %>
 
         <div class="container bg-base-100 p-6 rounded-lg shadow flex-1">
+          <h3 class="text-sm mb-6">オリジナルのアイテムを追加</h3>
           <%= form_with model: @new_original_item, url: item_list_items_path(@item_list), local: true do |f| %>
             <label class="form-control w-full max-w-xs">
               <input type="text" placeholder="アイテムの名前" name="original_item[name]" class="input input-bordered w-full max-w-xs" required />

--- a/app/views/recommends/_form.html.erb
+++ b/app/views/recommends/_form.html.erb
@@ -1,10 +1,17 @@
 <%= form_with model: @recommend, class: "space-y-4 bg-slate-50" do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
   <div>
-    <%= f.label :place, class: "block text-sm font-medium mb-1" %>
+    <div class="flex items-center">
+      <%= f.label :place, class: "block text-sm font-medium" %>
+      <span class="text-accent ml-1">*</span>
+    </div>
     <%= f.text_field :place, class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
   </div>
   <div>
-    <%= f.label :item, class: "block text-sm font-medium mb-1" %>
+    <div class="flex items-center">
+      <%= f.label :item, class: "block text-sm font-medium mb-1" %>
+      <span class="text-accent ml-1">*</span>
+    </div>
     <%= f.text_field :item, class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
   </div>
   <div>

--- a/db/migrate/20241114025702_remove_unique_index_from_item_lists.rb
+++ b/db/migrate/20241114025702_remove_unique_index_from_item_lists.rb
@@ -1,6 +1,6 @@
 class RemoveUniqueIndexFromItemLists < ActiveRecord::Migration[7.2]
   def change
     remove_index :item_lists, :name
-    remove_index :item_lists, [:user_id, :name] if index_exists?(:item_lists, [:user_id, :name])
+    remove_index :item_lists, [ :user_id, :name ] if index_exists?(:item_lists, [ :user_id, :name ])
   end
 end

--- a/db/migrate/20241114025702_remove_unique_index_from_item_lists.rb
+++ b/db/migrate/20241114025702_remove_unique_index_from_item_lists.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueIndexFromItemLists < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :item_lists, :name
+    remove_index :item_lists, [:user_id, :name] if index_exists?(:item_lists, [:user_id, :name])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_11_124325) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_14_025702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_11_124325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "cover_image"
-    t.index ["name"], name: "index_item_lists_on_name", unique: true
     t.index ["user_id"], name: "index_item_lists_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
エラーハンドリング
### 内容
- 持ち物リストのユニークインデックスを修正
- 同一ユーザーが同名の持ち物リストを複数作成できるよう修正
- 空の持ち物リストを保存できるよう設定
- 空の持ち物リストを共有できないよう設定
- 空の持ち物リストでアイテム数変更ボタンを押した際のメッセージを追加
- 同名のオリジナルアイテムを作成できるよう設定
- リストを共有中ボタンから投稿に遷移するよう設定
- マストアイテム投稿フォームの入力時エラー、必須項目のアスタリスクを追加