### PR TITLE
アバターのアップロード

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,6 +21,6 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name)
+    params.require(:user).permit(:email, :name, :avatar, :avatar_cache)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,6 @@ class User < ApplicationRecord
   def own?(object)
     id == object&.user_id
   end
+
+  mount_uploader :avatar, AvatarUploader
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,66 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+  def default_url
+    "default_avatar.png"
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+  process resize_to_fit: [ 400, 400 ]
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w[jpg jpeg gif png]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  process :convert_to_webp
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format "webp"
+      img
+    end
+  end
+
+  def filename
+    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
+  end
+end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,16 +2,22 @@
   <div class="flex items-center justify-center p-5">
     <div class="max-w-md w-full mx-auto bg-slate-50 p-6 rounded shadow">
       <div class="flex flex-col">
-        <%= image_tag "default_avatar.png", class: "w-16 h-16" %>
-        <%= form_with model: @user, url: profile_path, method: :put, class: "space-y-4" do |f| %>
+        <%= form_with model: @user, url: profile_path, method: :put do |f| %>
           <%= render 'shared/error_messages', object: f.object %>
-          <label class="form-control w-full">
+          <div class="mb-4">
+            <%= f.label :avatar, style: "cursor: pointer;" do %>
+              <%= image_tag(current_user.avatar_url, class: "w-16 h-16 rounded-full hover:opacity-50") %>
+            <% end %>
+            <%= f.file_field :avatar, class: "hidden", accept: 'image/*' %>
+            <%= f.hidden_field :avatar_cache %>
+          </div>
+          <label class="form-control w-full mb-4">
             <div class="label">
               <span class="label-text">アカウント名</span>
             </div>
             <%= f.text_field :name, class: "input input-bordered w-full bg-slate-50" %>
           </label>
-          <label class="form-control w-full">
+          <label class="form-control w-full mb-4">
             <div class="label">
               <span class="label-text">メールアドレス</span>
             </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
     <div class="max-w-md w-full mx-auto bg-slate-50 p-6 rounded shadow">
       <div class="flex flex-col">
         <div class="flex items-center gap-8">
-          <%= image_tag "default_avatar.png", class: "w-16 h-16" %>
+          <%= image_tag current_user.avatar_url, class: "w-16 h-16 rounded-full" %>
           <div class="flex flex-col space-y-2">
             <span class="text-base text-gray-900 text-lg">
               <%= current_user.decorate.name %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,13 +12,13 @@
         <div class="dropdown dropdown-hover dropdown-bottom dropdown-end">
           <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar mr-4">
             <div class="w-10 rounded-full">
-              <%= image_tag "default_avatar.png", class: "w-10 h-10" %>
+              <%= image_tag current_user.avatar_url, class: "w-10 h-10" %>
             </div>
           </div>
           <ul tabindex="0" class="dropdown-content menu bg-slate-50 text-neutral rounded-box z-[1] w-64 h-32 p-2 shadow space-y-4">
             <li>
               <%= link_to profile_path, class: "text-base flex items-center" do %>
-                <span class="material-symbols-outlined">person</span>
+                <span class="material-symbols-outlined mr-2">person</span>
                 <%= current_user.decorate.name %>
               <% end %>
             </li>

--- a/db/migrate/20241121104030_add_avatar_to_users.rb
+++ b/db/migrate/20241121104030_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_14_025702) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_21_104030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_14_025702) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
アバターのアップロード
### 内容
- avatar_uploaderを生成
- usersテーブルにavatarカラムを追加
- ストロングパラメータを追加
- 画像を.webpに変換するよう設定
- プロフィール編集にアバターのアップロードボタンを追加
- プロフィール詳細とログイン後のヘッダーにアバターを表示