### PR TITLE
アイテム表示順・オリジナルのアイテム追加時のチェックを修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,7 +15,7 @@ class ItemsController < ApplicationController
 
     if new_original_item.save
       item_list_original_item = ItemListOriginalItem.find_or_create_by(item_list: @item_list, original_item: new_original_item)
-      item_status = ItemStatus.create(item_list: @item_list, original_item: new_original_item, position: max_position + 1, is_checked: false, selected: false, quantity: 1)
+      item_status = ItemStatus.create(item_list: @item_list, original_item: new_original_item, position: max_position + 1, is_checked: false, selected: true, quantity: 1)
       redirect_to new_item_list_item_path(@item_list)
     else
       render :new

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -3,22 +3,22 @@
   <div class="max-w-md w-full p-6 rounded shadow">
     <h1 class="text-lg font-medium mb-6">パスワード再設定</h1>
 
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, class: "space-y-4") do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
       <div class="field">
-        <%= f.label :password, "新しいパスワード", class: "text-sm" %><br />
-        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-bordered input-sm w-full" %>
+        <%= f.label :password, "新しいパスワード", class: "text-sm" %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-bordered input-sm w-full mb-4" %>
       </div>
 
       <div class="field">
-        <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "text-sm" %><br />
+        <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "text-sm" %>
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered input-sm w-full" %>
       </div>
 
       <div class="actions">
-        <%= f.submit "パスワードを再設定", class: "btn btn-primary w-full mt-4" %>
+        <%= f.submit "パスワードを再設定", class: "btn btn-primary w-full mt-6" %>
       </div>
     <% end %>
   </div>

--- a/app/views/item_lists/show.html.erb
+++ b/app/views/item_lists/show.html.erb
@@ -26,15 +26,15 @@
     <div class="container flex flex-col justify-center items-center mt-8 gap-4">
       <% if @selected_original_items.empty? && @selected_default_items.empty? %>
         <p class="text-center text-gray-500">持ち物がありません</p>
-      <% else %>
-        <% @selected_original_items.each do |item| %>
+      <% else %>        
+        <% @selected_default_items.each do |item| %>
           <% status = item.item_statuses.find_by(item_list_id: @item_list.id) %>
           <div class="flex items-center gap-2 w-full max-w-md">
             <%= render "item_statuses/item_status", item_status: status %>
           </div>
         <% end %>
-        
-        <% @selected_default_items.each do |item| %>
+
+        <% @selected_original_items.each do |item| %>
           <% status = item.item_statuses.find_by(item_list_id: @item_list.id) %>
           <div class="flex items-center gap-2 w-full max-w-md">
             <%= render "item_statuses/item_status", item_status: status %>


### PR DESCRIPTION
## 概要
アイテム表示順・オリジナルのアイテム追加時のチェックを修正

### 内容
- 持ち物リスト詳細で既存のアイテム→オリジナルのアイテムの順に表示
- オリジナルアイテムの追加時、selected:trueになるよう修正
- パスワードリセット画面のレイアウトを変更