### PR TITLE
持ち物リスト複製時、カバー画像のリンク切れを修正

### DIFF
--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -24,6 +24,7 @@ class ItemList < ApplicationRecord
   def duplicate
     duplicated_list = self.dup
     duplicated_list.name = "#{self.name}のコピー"
+    duplicated_list.cover_image = nil
     duplicated_list.save!
 
     self.original_items.each do |original_item|


### PR DESCRIPTION
## 概要
持ち物リスト複製時、カバー画像のリンク切れを修正

### 内容
- リスト複製時にカバー画像を複製しないよう設定