### PR TITLE
持ち物リスト複製時、カバー画像と準備状況を複製しないよう設定

### DIFF
--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -22,8 +22,10 @@ class ItemList < ApplicationRecord
   end
 
   def duplicate
-    duplicated_list = self.dup
+    duplicated_list = ItemList.new
     duplicated_list.name = "#{self.name}のコピー"
+    duplicated_list.user_uuid = self.user_uuid
+    duplicated_list.ready_status = 0
     duplicated_list.cover_image = nil
     duplicated_list.save!
 


### PR DESCRIPTION
## 概要
持ち物リスト複製時、カバー画像と準備状況を複製しないよう設定

### 内容
- dupメソッドを使用するとカバー画像が複製されるため、新しいインスタンスを作成するよう修正
- 準備状況が0%の状態で複製されるよう修正