### PR TITLE
準備済みのアイテムをクリア

### DIFF
--- a/app/controllers/item_lists_controller.rb
+++ b/app/controllers/item_lists_controller.rb
@@ -1,4 +1,6 @@
 class ItemListsController < ApplicationController
+  include ActionView::RecordIdentifier
+
   def index
     @item_lists = ItemList.where(user_uuid: current_user.uuid).includes(:user).order(created_at: :asc)
     @bag_contents = BagContent.all
@@ -73,6 +75,13 @@ class ItemListsController < ApplicationController
     @item_list = ItemList.find(params[:id])
     duplicated_item_list = @item_list.duplicate
     redirect_to item_lists_path
+  end
+
+  def clear_checked_items
+    @item_list = ItemList.find(params[:id])
+    @item_list.clear_checked_items
+    @item_statuses = @item_list.item_statuses
+    redirect_to item_list_path(@item_list)
   end
 
   private

--- a/app/models/item_list.rb
+++ b/app/models/item_list.rb
@@ -63,4 +63,9 @@ class ItemList < ApplicationRecord
 
     duplicated_list
   end
+
+  def clear_checked_items
+    item_statuses.where(is_checked: true).update_all(is_checked: false)
+    update!(ready_status: 0)
+  end
 end

--- a/app/views/item_lists/show.html.erb
+++ b/app/views/item_lists/show.html.erb
@@ -15,6 +15,12 @@
               <span class="material-symbols-outlined">exposure_plus_1</span>
               アイテム数を変更
             <% end %>
+            <%= form_with url: clear_checked_items_item_list_path(@item_list), method: :patch, local: true do %>
+              <button type="submit" class="btn btn-primary flex items-center w-full">
+                <span class="material-symbols-outlined">refresh</span>
+                準備済みのアイテムをクリア
+              </button>
+            <% end %>
             <button class="btn btn-ghost w-full" onclick="document.getElementById('itemModal').close()">キャンセル</button>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resources :quantities, only: %i[index edit update]
     resources :bag_contents, only: %i[show new create]
     post :duplicate, on: :member
+    patch :clear_checked_items, on: :member
   end
 
   resources :bag_contents, only: %i[index edit update destroy]


### PR DESCRIPTION
## 概要
準備済みのアイテムをクリア

### 内容
- ItemListモデルにリストを複製するメソッドを追加
- ルーティング、コントローラーを追加
- 持ち物リスト詳細のメニューに準備済みのアイテムをクリアするボタンを追加