### PR TITLE
プライバシーポリシーページのセキュリティ対策

### DIFF
--- a/app/views/static_pages/policy.html.erb
+++ b/app/views/static_pages/policy.html.erb
@@ -56,7 +56,7 @@
     <div class="mb-6">
       <h2 class="mb-2 text-base md:text-lg font-bold dark:text-neutral">アクセス解析ツール</h2>
       <p class="mb-2 text-xs md:text-sm leading-7 text-gray-700 dark:text-neutral">当社は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
-      <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "link link-primary text-xs md:text-sm dark:link-secondary" %>
+      <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", rel: "noopener", class: "link link-primary text-xs md:text-sm dark:link-secondary" %>
     </div>
 
     <div class="mb-6">


### PR DESCRIPTION
## 概要
プライバシーポリシーページのセキュリティ対策

### 内容
- Googleアナリティクス利用規約のリンクに`rel: "noopener"`を追記