### PR TITLE
準備済みのアイテムの表示・非表示を切り替え

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import "./modals"
 import "./password_toggle"
+import "./item_status_toggle";

--- a/app/javascript/item_status_toggle.js
+++ b/app/javascript/item_status_toggle.js
@@ -1,0 +1,64 @@
+// Turboのページ読み込み完了時に実行
+document.addEventListener("turbo:load", () => {
+  // アイテムの状態を切り替えるボタンを取得
+  const toggleButtons = document.querySelectorAll("[data-toggle='item-status']");
+  
+  // ボタン、アイコン、テキストの要素を取得
+  const filterButton = document.getElementById("filterChecked");
+  const filterIcon = document.getElementById("filterIcon");
+  const filterText = document.getElementById("filterText");
+
+  // ローカルストレージから「準備済みのアイテムを非表示」の状態を取得（デフォルトはfalse）
+  let hideCheckedItems = JSON.parse(localStorage.getItem("hideCheckedItems")) || false;
+
+  // アイテムの表示/非表示を更新
+  function updateItemVisibility() {
+    toggleButtons.forEach((button) => {
+      // 各ボタンがチェックされているかどうかを判定
+      const isChecked = button.dataset.checked === "true"; // ボタンに設定されたチェック状態を取得
+      const listItem = button.closest("li"); // ボタンの親要素であるli要素を取得
+
+      if (listItem) {
+        // hideCheckedItemsがtrueで、アイテムがチェック済みならば非表示にする
+        if (hideCheckedItems && isChecked) {
+          listItem.classList.add("hidden"); // 非表示にするクラスを追加
+        } else {
+          listItem.classList.remove("hidden"); // 非表示にするクラスを削除
+        }
+      }
+    });
+  }
+
+  // ページが最初に読み込まれた時に初期化
+  function initialize() {
+    // 初期状態でアイテムの表示/非表示を更新
+    updateItemVisibility();
+
+    // ボタンのテキストとアイコンを更新
+    if (filterButton) {
+      filterText.textContent = hideCheckedItems
+        ? "準備済みのアイテムを表示"
+        : "準備済みのアイテムを非表示";
+      filterIcon.textContent = hideCheckedItems ? "visibility" : "visibility_off";
+    }
+  }
+
+  // ボタンがクリックされた時
+  function toggleFilter() {
+    // 状態を反転させ、表示/非表示を切り替え
+    hideCheckedItems = !hideCheckedItems;
+    
+    // 新しい状態をローカルストレージに保存
+    localStorage.setItem("hideCheckedItems", JSON.stringify(hideCheckedItems));
+
+    // アイコンとテキストを更新
+    filterIcon.textContent = hideCheckedItems ? "visibility" : "visibility_off";
+    filterText.textContent = hideCheckedItems ? "準備済みのアイテムを表示" : "準備済みのアイテムを非表示";
+
+    // アイテムの表示/非表示を再更新
+    updateItemVisibility();
+  }
+
+  // ページが読み込まれた時に初期化処理を実行
+  initialize();
+});

--- a/app/views/item_lists/show.html.erb
+++ b/app/views/item_lists/show.html.erb
@@ -21,6 +21,10 @@
                 準備済みのアイテムをクリア
               </button>
             <% end %>
+            <button id="filterChecked" class="btn btn-primary w-full gap-4" onclick="document.getElementById('itemModal').close()">
+              <span class="material-symbols-outlined" id="filterIcon">visibility_off</span>
+              <span id="filterText">準備済みのアイテムを非表示</span>
+            </button>
             <button class="btn btn-ghost w-full" onclick="document.getElementById('itemModal').close()">キャンセル</button>
           </div>
         </div>

--- a/app/views/item_statuses/_item_status.html.erb
+++ b/app/views/item_statuses/_item_status.html.erb
@@ -2,6 +2,7 @@
   <turbo-frame id="<%= dom_id(item_status) %>" class="w-full">
     <%= button_to toggle_item_status_path(item_status), 
                   method: :patch, 
+                  data: { toggle: "item-status", checked: item_status.is_checked },
                   class: "btn w-full flex justify-between items-center text-left px-4 
                          #{item_status.is_checked ? 'btn-active' : 'btn-inactive'} 
                          #{item_status.is_checked ? 'bg-secondary border-0 shadow dark:bg-base-200' : 'bg-base-100'}" do %>


### PR DESCRIPTION
## 概要
準備済みのアイテムの表示・非表示を切り替え

### 内容
- app/javascript/item_status_toggle.jsを生成
- アイテムのボタンにdata-checked 属性を追加
- 持ち物リスト詳細のメニューに準備済みのアイテムの表示・非表示を切り替えるボタンを追加