### PR TITLE
持ち物リスト共有の修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,3 +10,12 @@
   opacity: 0;
   visibility: hidden;
 }
+
+span.size-24 {
+  font-size: 24px;
+  font-variation-settings: 'OPSZ' 24;
+}
+span.size-30 {
+  font-size: 30px;
+  font-variation-settings: 'OPSZ' 30;
+}

--- a/app/controllers/bag_contents_controller.rb
+++ b/app/controllers/bag_contents_controller.rb
@@ -29,7 +29,7 @@ class BagContentsController < ApplicationController
     @item_list = ItemList.find(params[:item_list_id])
     @bag_content = current_user.bag_contents.new(item_list_id: @item_list.id)
     tag_names = params[:tag_name]
-  
+
     if @item_list.original_items.empty? && @item_list.default_items.empty?
       flash[:alert] = "空の持ち物リストは共有できません"
       redirect_to item_list_path(@item_list)

--- a/app/controllers/bag_contents_controller.rb
+++ b/app/controllers/bag_contents_controller.rb
@@ -1,10 +1,16 @@
 class BagContentsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
-  before_action :set_item_list, only: %i[ show new create ]
   helper_method :prepare_meta_tags
 
   def index
     bag_contents = BagContent.all
+    @search_form = SearchForm.new(search_params)
+    @bag_contents = @search_form.search(bag_contents).order(created_at: :desc)
+  end
+
+  def show
+    @bag_content = BagContent.find_by(uuid: params[:id])
+    @item_list = @bag_content.item_list
 
     bag_contents = if (tag_name = params[:tag_name])
       bag_contents.with_tag(tag_name)
@@ -12,38 +18,28 @@ class BagContentsController < ApplicationController
       bag_contents
     end
 
-    @search_form = SearchForm.new(search_params)
-    @bag_contents = @search_form.search(bag_contents).order(created_at: :desc)
-  end
-
-  def show
-    @bag_content = BagContent.find_by(uuid: params[:id])
     prepare_meta_tags(@bag_content)
   end
 
   def new
-    @bag_content = current_user.bag_contents.new
+    @bag_content = BagContent.new
   end
 
   def create
-    @bag_content = @item_list.bag_contents.find_by(user: current_user)
-
+    @item_list = ItemList.find(params[:item_list_id])
+    @bag_content = current_user.bag_contents.new(item_list_id: @item_list.id)
+    tag_names = params[:tag_name]
+  
     if @item_list.original_items.empty? && @item_list.default_items.empty?
-      redirect_to item_list_path(@item_list), alert: "空の持ち物リストは共有できません"
-      return
-    end
-
-    if @bag_content.nil?
-      @bag_content = BagContent.new(bag_content_params)
-    end
-
-    if current_user.bag_contents.exists?(item_list_id: @item_list.id)
-      redirect_to item_list_path(@item_list), alert: "この持ち物リストは既に共有されています"
+      flash[:alert] = "空の持ち物リストは共有できません"
+      redirect_to item_list_path(@item_list)
     else
-      @bag_content = current_user.bag_contents.new(bag_content_params.merge(item_list: @item_list))
-
-      if @bag_content.save_with_tags(tag_name: params.dig(:bag_content, :tag_name).split(",").uniq)
-        redirect_to item_list_bag_contents_path(@item_list), notice: "持ち物リストを共有しました"
+      if @bag_content.save
+        if tag_names.present?
+          tags = tag_names.split(" ").map(&:strip).uniq
+          create_or_update_bag_content_tags(@bag_content, tags)
+        end
+        redirect_to bag_content_path(@bag_content), notice: "持ち物リストを共有しました"
       else
         render :new, alert: "持ち物リストを共有できませんでした"
       end
@@ -57,9 +53,14 @@ class BagContentsController < ApplicationController
   def update
     @bag_content = current_user.bag_contents.find_by(uuid: params[:id])
     @bag_content.body = bag_content_params[:body]
+    tag_names = params[:bag_content][:tag_names]
 
-    if @bag_content.save_with_tags(tag_name: params.dig(:bag_content, :tag_name).split(",").uniq)
-      redirect_to bag_contents_path(@bag_content), notice: "投稿を更新しました"
+    if @bag_content.update(bag_content_params)
+      if tag_names.present?
+        tags = params[:bag_content][:tag_names].split(" ").map(&:strip).uniq
+        create_or_update_bag_content_tags(@bag_content, tags)
+      end
+      redirect_to bag_content_path(@bag_content), notice: "投稿を更新しました"
     else
       flash.now[:alert] = "投稿を更新できませんでした"
       render :edit, status: :unprocessable_entity
@@ -74,8 +75,16 @@ class BagContentsController < ApplicationController
 
   private
 
-  def set_item_list
-    @item_list = ItemList.find(params[:item_list_id])
+  def create_or_update_bag_content_tags(bag_content, tags)
+    bag_content.tags.destroy_all
+    begin
+    tags.each do |tag|
+      tag = Tag.find_or_create_by(name: tag)
+      bag_content.tags << tag
+      rescue ActiveRecord::RecordInvalid
+        false
+      end
+    end
   end
 
   def search_params
@@ -101,6 +110,6 @@ class BagContentsController < ApplicationController
   end
 
   def bag_content_params
-    params.require(:bag_content).permit(:item_list_id, :body, tag_ids: [])
+    params.require(:bag_content).permit(:item_list_id, :body)
   end
 end

--- a/app/controllers/bag_contents_controller.rb
+++ b/app/controllers/bag_contents_controller.rb
@@ -31,7 +31,7 @@ class BagContentsController < ApplicationController
     tag_names = params[:tag_name]
 
     if @item_list.original_items.empty? && @item_list.default_items.empty?
-      flash[:alert] = "空の持ち物リストは共有できません"
+      flash[:alert] = t("defaults.flash_message.empty_list", item: BagContent.model_name.human)
       redirect_to item_list_path(@item_list)
     else
       if @bag_content.save
@@ -39,9 +39,9 @@ class BagContentsController < ApplicationController
           tags = tag_names.split(" ").map(&:strip).uniq
           create_or_update_bag_content_tags(@bag_content, tags)
         end
-        redirect_to bag_content_path(@bag_content), notice: "持ち物リストを共有しました"
+        redirect_to bag_content_path(@bag_content), notice: t("defaults.flash_message.shared", item: BagContent.model_name.human)
       else
-        render :new, alert: "持ち物リストを共有できませんでした"
+        render :new, alert: t("defaults.flash_message.not_shared", item: BagContent.model_name.human)
       end
     end
   end
@@ -60,9 +60,9 @@ class BagContentsController < ApplicationController
         tags = params[:bag_content][:tag_names].split(" ").map(&:strip).uniq
         create_or_update_bag_content_tags(@bag_content, tags)
       end
-      redirect_to bag_content_path(@bag_content), notice: "投稿を更新しました"
+      redirect_to bag_content_path(@bag_content), notice: t("defaults.flash_message.updated", item: BagContent.model_name.human)
     else
-      flash.now[:alert] = "投稿を更新できませんでした"
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: BagContent.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/bag_content.rb
+++ b/app/models/bag_content.rb
@@ -9,21 +9,6 @@ class BagContent < ApplicationRecord
 
   mount_uploader :ogp, OgpUploader
 
-  def save_with_tags(tag_name:)
-    ActiveRecord::Base.transaction do
-      self.tags = tag_name.map { |name| Tag.find_or_initialize_by(name: name.strip) }
-      save!
-    end
-    true
-  rescue StandardError
-    false
-  end
-
-  def tag_name
-    # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
-    tags.map(&:name).join(",")
-  end
-
   def image_path
     if self.item_list.present? && self.item_list.cover_image.present?
       Rails.env.production? ? self.item_list.cover_image.url : self.item_list.cover_image.path

--- a/app/models/bag_content_tag.rb
+++ b/app/models/bag_content_tag.rb
@@ -3,4 +3,5 @@ class BagContentTag < ApplicationRecord
   belongs_to :tag
 
   validates :tag_id, uniqueness: { scope: :bag_content_uuid }
+  validates :bag_content_uuid, presence: true
 end

--- a/app/views/bag_contents/_bag_content.html.erb
+++ b/app/views/bag_contents/_bag_content.html.erb
@@ -6,7 +6,7 @@
       </div>
     </div>
     <figure class="w-full h-full">
-      <%= link_to item_list_bag_content_path(bag_content.item_list, bag_content), class: "w-full h-full block" do %>
+      <%= link_to bag_content_path(bag_content.uuid), class: "w-full h-full block" do %>
         <%= image_tag bag_content.item_list.cover_image.url, class: "w-full h-full object-cover object-bottom" %>
       <% end %>
     </figure>
@@ -18,7 +18,7 @@
         <%= bag_content.item_list.name %>
       </div>
     </div>
-    <%= link_to item_list_bag_content_path(bag_content.item_list, bag_content), class: "w-full h-full block rounded-b-lg bg-base-200 dark:bg-base-300" do %>
+    <%= link_to bag_content_path(bag_content.uuid), class: "w-full h-full block rounded-b-lg bg-base-200 dark:bg-base-300" do %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/bag_contents/_bookmark.html.erb
+++ b/app/views/bag_contents/_bookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmarks_path(bookmarkable: bag_content), id: "bookmark-button-for-bag_content-#{bag_content.uuid}", data: { turbo_method: :post } do %>
-  <span class="material-symbols-outlined text-primary dark:text-neutral">bookmark</span>
+  <span class="material-symbols-outlined  size-30 text-primary dark:text-neutral">bookmark</span>
 <% end %>

--- a/app/views/bag_contents/_tags.html.erb
+++ b/app/views/bag_contents/_tags.html.erb
@@ -1,0 +1,5 @@
+<div class="flex flex-wrap gap-2 mb-4">
+  <% @bag_content.tags.each do |tag| %>
+    <%= link_to tag.name, bag_content_path(tag_name: tag.name), class: 'badge badge-primary badge-md text-white text-xs', style: 'pointer-events: none; cursor: default;' %>
+  <% end %>
+</div>

--- a/app/views/bag_contents/_tags.html.erb
+++ b/app/views/bag_contents/_tags.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-wrap gap-2 mb-4">
   <% @bag_content.tags.each do |tag| %>
-    <%= link_to tag.name, bag_content_path(tag_name: tag.name), class: 'badge badge-primary badge-md text-white text-xs', style: 'pointer-events: none; cursor: default;' %>
+    <%= link_to tag.name, bag_content_path(tag_name: tag.name), class: 'badge badge-md bg-gradient-to-r from-primary to-cyan-500 text-white text-[10px]', style: 'pointer-events: none; cursor: default;' %>
   <% end %>
 </div>

--- a/app/views/bag_contents/_unbookmark.html.erb
+++ b/app/views/bag_contents/_unbookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmark_path(current_user.bookmarks.find_by(bookmarkable: bag_content)), id: "unbookmark-button-for-bag_content-#{bag_content.uuid}", data: { turbo_method: :delete } do %>
-  <span class="material-symbols-outlined text-primary dark:text-neutral" style="font-variation-settings: 'FILL' 1;">bookmark</span>
+  <span class="material-symbols-outlined  size-30 text-primary dark:text-neutral" style="font-variation-settings: 'FILL' 1;">bookmark</span>
 <% end %>

--- a/app/views/bag_contents/edit.html.erb
+++ b/app/views/bag_contents/edit.html.erb
@@ -1,36 +1,36 @@
 <% content_for(:title, t('.title')) %>
-  <div class="flex items-center justify-center p-5">
-    <div class="max-w-md w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
-      <div class="flex items-center space-x-4">
-        <h1 class="text-lg font-medium mb-6"><%= t('.title') %></h1>
-      </div>
-      <%= form_with model: @bag_content, url: bag_content_path(@bag_content), local: true do |f| %>
-        <div>
-          <%= f.label :tag_name, "タグ", class: "block text-sm font-medium mb-2" %>
-          <%= f.text_field :tag_name, placeholder: "カンマ区切りで入力", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200" %>
-        </div>
-        <div class="mt-4">
-          <%= f.label :body, class: "block text-sm font-medium mb-2" %>
-          <%= f.text_area :body, placeholder: "こだわりポイント、おすすめのアイテムなど", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200", rows: 5 %>
-        </div>
-        <div class="modal-action mt-4">
-          <%= f.submit t('bag_contents.edit.submit_label'), class: "btn btn-primary w-full" %>
-        </div>
-      <% end %>
-      <% if user_signed_in? && current_user.own?(@bag_content) %>
-        <button class="btn btn-base-300 w-full mt-4 dark:btn-outline" onclick="openBagContentDeleteModal('<%= j @bag_content.uuid %>')"><%= t('bag_contents.delete.submit_label') %></button>
-        <dialog id="bagContentDeleteModal_<%= j @bag_content.uuid %>" class="modal">
-          <div class="modal-box bg-slate-50 w-96 mx-auto px-4 space-y-6 dark:bg-base-200">
-            <div class="text-left">
-              <h3 class="font-semibold text-base text-accent mb-2">投稿を削除しますか？</h3>
-              <p class="text-sm">共有していた持ち物リストは削除されません。</p>
-            </div>
-            <%= form_with url: bag_content_path(@bag_content), method: :delete, class: "w-full" do |f| %>
-              <button class="btn w-full btn-accent text-white font-normal" type="submit">削除する</button>
-            <% end %>
-            <button class="btn w-full" onclick="document.getElementById('bagContentDeleteModal_<%= j @bag_content.uuid %>').close()">キャンセル</button>
-          </div>
-        </dialog>
-      <% end %>
+<div class="flex items-center justify-center p-5">
+  <div class="max-w-xl w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
+    <div class="flex items-center">
+      <h1 class="text-lg font-medium mb-4"><%= @bag_content.item_list.name %></h1>
     </div>
+    <%= form_with model: @bag_content, url: bag_content_path(@bag_content), class: "w-full space-y-4", local: true do |f| %>
+      <div>
+        <%= f.label :tag_name, "タグ", class: "block text-sm font-normal mb-2" %>
+        <%= f.text_field :tag_names, value: @bag_content.tags.map(&:name).join(" "), placeholder: "スペース区切りで入力", class: "w-full border border-gray-300 bg-slate-50 text-xs md:text-sm rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200" %>
+      </div>
+      <div class="mt-4">
+        <%= f.label :body, class: "block text-sm font-normal mb-2" %>
+        <%= f.text_area :body, placeholder: "こだわりポイント、おすすめのアイテムなど", class: "w-full border border-gray-300 bg-slate-50 text-xs md:text-sm rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200", rows: 5 %>
+      </div>
+      <div class="modal-action mt-8">
+        <%= f.submit t('bag_contents.edit.submit_label'), class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+    <% if user_signed_in? && current_user.own?(@bag_content) %>
+      <button class="btn btn-base-300 w-full my-4 dark:btn-outline" onclick="openBagContentDeleteModal('<%= j @bag_content.uuid %>')"><%= t('bag_contents.delete.submit_label') %></button>
+      <dialog id="bagContentDeleteModal_<%= j @bag_content.uuid %>" class="modal">
+        <div class="modal-box bg-slate-50 w-96 mx-auto px-4 space-y-6 dark:bg-base-200">
+          <div class="text-left">
+            <h3 class="font-semibold text-base text-accent mb-2">投稿を削除しますか？</h3>
+            <p class="text-sm">共有していた持ち物リストは削除されません。</p>
+          </div>
+          <%= form_with url: bag_content_path(@bag_content), method: :delete, class: "w-full" do |f| %>
+            <button class="btn w-full btn-accent text-white font-normal" type="submit">削除する</button>
+          <% end %>
+          <button class="btn w-full" onclick="document.getElementById('bagContentDeleteModal_<%= j @bag_content.uuid %>').close()">キャンセル</button>
+        </div>
+      </dialog>
+    <% end %>
   </div>
+</div>

--- a/app/views/bag_contents/index.html.erb
+++ b/app/views/bag_contents/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="flex flex-col justify-start items-start bg-base-100">
     <div class="flex flex-col items-start bg-base-100">
       <div class="flex items-center mb-6">

--- a/app/views/bag_contents/show.html.erb
+++ b/app/views/bag_contents/show.html.erb
@@ -44,18 +44,24 @@
       </div>
     </div>
 
-    <div class="flex justify-end items-center gap-4 mt-6">
-      <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{request.url}&text=#{CGI.escape("#{@bag_content.item_list.name}の持ち物リスト")}%0A&hashtags=#{CGI.escape('AllReady')}" %>
-      <%= link_to twitter_share_url, target: '_blank', class: "mb-1.5" do %>
-        <i class="fa-brands fa-x-twitter fa-lg text-primary dark:text-neutral"></i>
+    <div class="flex justify-between items-center mt-6">
+      <%= link_to bag_contents_path, class: "flex items-center gap-2 text-sm" do %>
+        <span class="material-symbols-outlined text-primary dark:text-neutral">arrow_back_ios_new</span>
+        もどる
       <% end %>
-
-      <%= render 'bookmark_buttons', { bag_content: @bag_content } %>
-      <% if user_signed_in? && current_user.own?(@bag_content) %>
-        <%= link_to edit_bag_content_path(@bag_content), id: "button-edit-#{@bag_content.uuid}" do %>
-          <span class="material-symbols-outlined text-primary dark:text-neutral">edit</span>
+      <div class="flex justify-end items-center gap-5">
+        <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{request.url}&text=#{CGI.escape("#{@bag_content.item_list.name}の持ち物リスト")}%0A&hashtags=#{CGI.escape('AllReady')}" %>
+        <%= link_to twitter_share_url, target: '_blank', class: "mb-1.5" do %>
+          <i class="fa-brands fa-x-twitter fa-xl text-primary dark:text-neutral"></i>
         <% end %>
-      <% end %>
+
+        <%= render 'bookmark_buttons', { bag_content: @bag_content } %>
+        <% if user_signed_in? && current_user.own?(@bag_content) %>
+          <%= link_to edit_bag_content_path(@bag_content), id: "button-edit-#{@bag_content.uuid}" do %>
+            <span class="material-symbols-outlined size-30 text-primary dark:text-neutral">edit</span>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/bag_contents/show.html.erb
+++ b/app/views/bag_contents/show.html.erb
@@ -10,10 +10,8 @@
           <p class="text-xs md:text-sm text-left"><%= @bag_content.user.name %></p>
         </div>
 
-        <% if @bag_content.tag_name.present? %>
-          <div class="flex flex-wrap gap-2 mb-4">
-            <%= render @bag_content.tags %>
-          </div>
+        <% if @bag_content.tags.present? %>
+          <%= render 'bag_contents/tags', bag_content: @bag_content %>
         <% end %>
 
         <% if @bag_content.body.present? %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="flex flex-col justify-center">
     <div class="fixed top-16 right-0 left-0 z-30 flex justify-start items-center bg-base-100 sticky">
       <span class="material-symbols-outlined md:text-2xl text-primary" style="font-variation-settings: 'FILL' 1;">bookmark</span>

--- a/app/views/item_lists/_item_list.html.erb
+++ b/app/views/item_lists/_item_list.html.erb
@@ -4,7 +4,7 @@
       <div class="flex-grow pl-2 pr-10 font-medium" style="cursor: default; word-wrap: break-word; overflow-wrap: break-word;">
         <%= item_list.name %>
       </div>
-      <span class="material-symbols-outlined absolute top-1.5 md:top-2.5 right-2 md:right-3 z-10" style="cursor: pointer;" onclick="openMenuModal(<%= item_list.id %>)">more_horiz</span>
+      <span class="material-symbols-outlined size-30 absolute top-1 md:top-2 right-2 md:right-3 z-10" style="cursor: pointer;" onclick="openMenuModal(<%= item_list.id %>)">more_horiz</span>
       <%= render 'item_list_modal', item_list: item_list %>
     </div>
     <figure class="w-full h-full">
@@ -19,7 +19,7 @@
       <div class="flex-grow pl-2 pr-10 font-medium" style="cursor: default; word-wrap: break-word; overflow-wrap: break-word;">
         <%= item_list.name %>
       </div>
-      <span class="material-symbols-outlined absolute top-1.5 md:top-2.5 right-2 md:right-3" style="cursor: pointer;" onclick="openMenuModal(<%= item_list.id %>)">more_horiz</span>
+      <span class="material-symbols-outlined size-30 absolute top-1 md:top-2 right-2 md:right-3" style="cursor: pointer;" onclick="openMenuModal(<%= item_list.id %>)">more_horiz</span>
       <%= render 'item_list_modal', item_list: item_list %>
     </div>
     <%= link_to item_list_path(item_list), class: "w-full h-full block rounded-b-lg bg-base-200 dark:bg-base-300" do %>

--- a/app/views/item_lists/_item_list_modal.html.erb
+++ b/app/views/item_lists/_item_list_modal.html.erb
@@ -19,15 +19,15 @@
         </button>
       <% end %>
       <% unless current_user.bag_contents.exists?(item_list_id: item_list.id) %>
-        <button class="btn w-full btn-outline text-primary font-normal bg-base-100 dark:bg-base-200 dark:text-neutral border-primary dark:border-neutral hover:bg-gray-100 hover:border-primary hover:text-primary
-          dark:hover:bg-base-300 dark:hover:border-neutral dark:hover:text-neutral" onclick="openShareModal(<%= item_list.id %>)">
-          <span class="material-symbols-outlined">share</span>
-          リストを共有
-        </button>
+       <button class="btn w-full btn-outline text-primary font-normal bg-base-100 dark:bg-base-200 dark:text-neutral border-primary dark:border-neutral hover:bg-gray-100 hover:border-primary hover:text-primary
+        dark:hover:bg-base-300 dark:hover:border-neutral dark:hover:text-neutral" onclick="openShareModal(<%= item_list.id %>)">
+        <span class="material-symbols-outlined">share</span>
+        リストを共有
+       </button>
       <% else %>
         <% @bag_contents.each do |bag_content| %>
           <% if bag_content.item_list_id == item_list.id %>
-            <%= link_to item_list_bag_content_path(item_list.id, bag_content.uuid), class: "btn w-full btn-primary font-normal", onclick: "document.getElementById('menuModal_#{item_list.id}').close();" do %>
+            <%= link_to bag_content_path(bag_content.uuid), class: "btn w-full btn-primary font-normal", onclick: "document.getElementById('menuModal_#{item_list.id}').close();" do %>
               <span class="material-symbols-outlined">share</span>
               リストを共有中
             <% end %>
@@ -86,20 +86,20 @@
       <h2 class="text-base font-medium mb-4">
         <%= link_to item_list.name, item_list_path(item_list) %>
       </h2>
-      <%= form_with model: @bag_content || BagContent.new(item_list_id: item_list.id), url: item_list_bag_contents_path(item_list), class: "w-full", local: true do |f| %>
+      <%= form_with model: @bag_content, url: bag_contents_path, method: :post, local: true do |f| %>
         <%= f.hidden_field :item_list_id, value: item_list.id %>
         <div>
-          <%= f.label :tag_name, "タグ　<span class='text-xs text-gray-500 dark:text-neutral'>(カンマ区切り・3つまで)</span>".html_safe, class: "block text-sm font-medium mb-2" %>
-          <%= f.text_field :tag_name, placeholder: "例：秋, 温泉, 食べ歩き", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200" %>
+          <%= f.label :tag_name, "タグ　<span class='text-xs text-gray-500 dark:text-neutral'>(スペース区切り・3つまで)</span>".html_safe, class: "block text-sm font-medium mb-2" %>
+          <%= f.text_field :tag_name, placeholder: "例：秋, 温泉, 食べ歩き", class: "w-full border border-gray-300 bg-slate-50 text-xs md:text-sm font-normal rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200" %>
         </div>
         <div class="mt-4">
-          <%= f.label :body, class: "block text-sm font-medium mb-2" %>
-          <%= f.text_area :body, placeholder: "こだわりポイント、おすすめのアイテムなど", class: "w-full border border-gray-300 bg-slate-50 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200", rows: 5 %>
+          <%= f.label :body, class: "block text-sm font-normal mb-2" %>
+          <%= f.text_area :body, placeholder: "こだわりポイント、おすすめのアイテムなど", class: "w-full border border-gray-300 bg-slate-50 text-xs md:text-sm font-normal rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500, placeholder:text-xs dark:bg-base-200", rows: 5 %>
         </div>
-        <div class="modal-action mt-4">
+        <p class="text-xs text-accent my-4">※空の持ち物リストは共有できません</p>
+        <div class="flex mt-4 justify-end">
           <%= f.submit t('bag_contents.new.submit_label'), class: "btn w-full btn-primary" %>
         </div>
-        <p class="text-xs text-accent mt-4">※空の持ち物リストは共有できません</p>
       <% end %>
       <div class="modal-action">
         <button class="btn w-full btn-ghost" onclick="document.getElementById('shareModal_<%= item_list.id %>').close()">キャンセル</button>

--- a/app/views/item_lists/index.html.erb
+++ b/app/views/item_lists/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="flex justify-start items-center bg-base-100">
     <div class="flex items-center">
       <span class="material-symbols-outlined md:text-2xl text-primary" style="font-variation-settings: 'FILL' 1;">playlist_add</span>

--- a/app/views/item_lists/show.html.erb
+++ b/app/views/item_lists/show.html.erb
@@ -3,7 +3,7 @@
     <div class="flex justify-between items-center mx-auto w-full">
       <h1 class="text-base md:text-lg font-medium text-center"><%= @item_list.name %></h1>
       <div class="md:hidden ml-auto">
-        <span class="material-symbols-outlined text-primary dark:text-neutral mt-2 mr-4" onclick="openItemModal()">edit_square</span>
+        <span class="material-symbols-outlined size-30 text-primary dark:text-neutral mt-2 mr-4" onclick="openItemModal()">edit_square</span>
         <dialog id="itemModal" class="modal md:hidden">
           <div class="modal-box bg-slate-50 w-96 mx-auto px-4 dark:bg-base-200">
             <div class="px-4 py-12 flex flex-col justify-center w-full space-y-8">

--- a/app/views/item_lists/show.html.erb
+++ b/app/views/item_lists/show.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="flex mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="container flex flex-col justify-start items-center md:w-1/2 md:ml-12 gap-4 w-full">
     <div class="flex justify-between items-center mx-auto w-full">
       <h1 class="text-base md:text-lg font-medium text-center"><%= @item_list.name %></h1>
@@ -32,7 +32,7 @@
         </dialog>
       </div>
     </div>
-    <div class="flex flex-col justify-center items-center mx-auto px-2 mt-4 gap-4 w-full">
+    <div class="flex flex-col justify-center items-center mx-auto mt-4 gap-4 w-full">
       <%= render "item_lists/ready_status", item_list: @item_list, id: dom_id(@item_list, :ready_status) %>
       <% if @selected_default_items.empty? && @selected_original_items.empty? %>
         <div class="w-full">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="flex flex-col md:flex-row w-full">
     <div class="flex flex-col justify-center w-full md:w-2/3 md:mr-8">
       <%= form_with(model: @item_list, local: true) do |f| %>
@@ -7,7 +7,7 @@
           <h1 class="text-base md:text-lg font-medium text-center mb-6 md:mb-0"><%= @item_list.name %></h1>
           <%= f.submit "リストを保存", class: "btn btn-primary" %>
         </div>
-        <div class="flex flex-col md:flex-row bg-slate-50 rounded shadow px-6 pl-2 md:pl-12 py-6 dark:bg-base-200">
+        <div class="flex flex-col md:flex-row bg-slate-50 rounded shadow px-6 md:pl-12 py-6 dark:bg-base-200">
           <div class="flex flex-col items-start gap-4 md:w-1/2">
             <h3 class="text-sm">既存のアイテム</h3>
             <% @sorted_items = @default_items %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,18 +2,18 @@
   <div class="flex items-center justify-center p-5 md:m-12">
     <div class="max-w-xl w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
       <div class="flex flex-col">
-        <div class="flex items-center gap-8">
+        <div class="flex flex-col justify-start space-y-4">
           <%= image_tag current_user.avatar_url, class: "w-20 h-20 rounded-full" %>
           <div class="flex flex-col space-y-2">
-            <span class="text-base text-gray-900 text-base md:text-lg dark:text-neutral">
+            <span class="text-base text-gray-900 text-base md:text-lg text-nowrap dark:text-neutral">
               <%= current_user.decorate.name %>
             </span>
-            <span class="text-base text-gray-900 text-base md:text-lg dark:text-neutral">
+            <span class="text-base text-gray-900 text-base md:text-lg text-nowrap dark:text-neutral">
               <%= current_user.email %>
             </span>
           </div>
         </div>
-      <div class="mt-12 justify-end">
+      <div class="mt-8 justify-end">
         <%= link_to t('profiles.show.submit_label'), edit_profile_path, class: 'btn btn-primary w-full' %>
       </div>
     </div>

--- a/app/views/recommends/_bookmark.html.erb
+++ b/app/views/recommends/_bookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmarks_path(bookmarkable: recommend), id: "bookmark-button-for-recommend-#{recommend.uuid}", data: { turbo_method: :post } do %>
-  <span class="material-symbols-outlined text-primary dark:text-neutral">bookmark</span>
+  <span class="material-symbols-outlined  size-30 text-primary dark:text-neutral">bookmark</span>
 <% end %>

--- a/app/views/recommends/_unbookmark.html.erb
+++ b/app/views/recommends/_unbookmark.html.erb
@@ -1,3 +1,3 @@
 <%= link_to bookmark_path(current_user.bookmarks.find_by(bookmarkable: recommend)), id: "unbookmark-button-for-recommend-#{recommend.uuid}", data: { turbo_method: :delete } do %>
-  <span class="material-symbols-outlined text-primary dark:text-neutral" style="font-variation-settings: 'FILL' 1;">bookmark</span>
+  <span class="material-symbols-outlined  size-30 text-primary dark:text-neutral" style="font-variation-settings: 'FILL' 1;">bookmark</span>
 <% end %>

--- a/app/views/recommends/by_place.html.erb
+++ b/app/views/recommends/by_place.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <h1 class="text-base md:text-lg font-medium mb-6 md:mb-12"><%= @place %>のマストアイテム</h1>
   <div class="flex flex-wrap justify-start gap-5 md:gap-10">
     <% if @recommends.present? %>

--- a/app/views/recommends/edit.html.erb
+++ b/app/views/recommends/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
   <div class="flex items-center justify-center p-5">
-    <div class="max-w-md w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
+    <div class="max-w-xl w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
       <div class="flex items-center space-x-4">
         <h1 class="text-lg font-medium mb-6"><%= t('.title') %></h1>
       </div>

--- a/app/views/recommends/index.html.erb
+++ b/app/views/recommends/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto pt-3 pl-2 md:pl-12 py-24">
+<div class="container mx-auto pt-3 p-2 md:pl-12 py-24">
   <div class="flex justify-start items-center bg-base-100">
     <div class="flex items-center">
       <span class="material-symbols-outlined md:text-2xl text-primary" style="font-variation-settings: 'FILL' 1;">lightbulb_2</span>

--- a/app/views/recommends/new.html.erb
+++ b/app/views/recommends/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
   <div class="flex items-center justify-center p-5">
-    <div class="max-w-md w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
+    <div class="max-w-xl w-full mx-auto bg-slate-50 p-6 rounded shadow dark:bg-base-200">
       <div class="flex items-center space-x-4">
         <h1 class="text-base md:text-lg font-medium mb-2 md:mb-6"><%= t('.title') %></h1>
       </div>

--- a/app/views/recommends/show.html.erb
+++ b/app/views/recommends/show.html.erb
@@ -20,19 +20,24 @@
           </div>
         <% end %>
       </div>
-
-      <div class="flex justify-end items-center gap-4 mt-6">
-        <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{request.url}&text=#{CGI.escape(@recommend.place)}のマストアイテム：#{CGI.escape(@recommend.item)}%0A&hashtags=#{CGI.escape('AllReady')}" %>
-        <%= link_to twitter_share_url, target: '_blank', class: "mb-1.5" do %>
-          <i class="fa-brands fa-x-twitter fa-lg text-primary dark:text-neutral"></i>
+      <div class="flex justify-between items-center mt-6">
+        <%= link_to by_place_recommends_path(@recommend.place), class: "flex items-center gap-2 text-sm" do %>
+          <span class="material-symbols-outlined text-primary dark:text-neutral">arrow_back_ios_new</span>
+          もどる
         <% end %>
-
-        <%= render 'bookmark_buttons', { recommend: @recommend } %>
-        <% if user_signed_in? && current_user.own?(@recommend) %>
-          <%= link_to edit_recommend_path(@recommend), id: "button-edit-#{@recommend.uuid}" do %>
-            <span class="material-symbols-outlined text-primary dark:text-neutral">edit</span>
+        <div class="flex justify-end items-center gap-5">
+          <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{request.url}&text=#{CGI.escape(@recommend.place)}のマストアイテム：#{CGI.escape(@recommend.item)}%0A&hashtags=#{CGI.escape('AllReady')}" %>
+          <%= link_to twitter_share_url, target: '_blank', class: "mb-1.5" do %>
+            <i class="fa-brands fa-x-twitter fa-xl text-primary dark:text-neutral"></i>
           <% end %>
-        <% end %>
+
+          <%= render 'bookmark_buttons', { recommend: @recommend } %>
+          <% if user_signed_in? && current_user.own?(@recommend) %>
+            <%= link_to edit_recommend_path(@recommend), id: "button-edit-#{@recommend.uuid}" do %>
+              <span class="material-symbols-outlined size-30 text-primary dark:text-neutral">edit</span>
+            <% end %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,1 +1,0 @@
-<%= link_to tag.name, item_list_bag_content_path(tag_name: tag.name), class: 'badge badge-primary badge-md text-white text-xs', style: 'pointer-events: none; cursor: default;' %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,9 @@ ja:
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
       require_login: ログインが必要です
+      empty_list: 空の持ち物リストは共有できません
+      shared: "%{item}を共有しました"
+      not_shared: "%{item}を共有できませんでした"
   header:
     login: ログイン
     logout: ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       delete "destroy_original_item/:id", action: :destroy_original_item, as: :destroy_original_item
     end
     resources :quantities, only: %i[index edit update]
-    
+
     post :duplicate, on: :member
     patch :clear_checked_items, on: :member
     patch :update_position, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,7 @@ Rails.application.routes.draw do
   }
 
   resources :recommends do
-    collection do
-      get "place/:place", to: "recommends#by_place", as: "by_place"
-    end
+    get "place/:place", to: "recommends#by_place", as: "by_place", on: :collection
   end
 
   resources :item_lists do
@@ -18,13 +16,13 @@ Rails.application.routes.draw do
       delete "destroy_original_item/:id", action: :destroy_original_item, as: :destroy_original_item
     end
     resources :quantities, only: %i[index edit update]
-    resources :bag_contents, only: %i[index show new create]
+    
     post :duplicate, on: :member
     patch :clear_checked_items, on: :member
     patch :update_position, on: :member
   end
 
-  resources :bag_contents, only: %i[index edit update destroy]
+  resources :bag_contents
 
   resources :item_statuses, only: %i[update] do
     patch :toggle, on: :member


### PR DESCRIPTION
## 概要
持ち物リスト共有の修正

### 内容
- タグやコメントのフォームに値が入っているとリストを共有できない不具合を解消
- bag_contentsのルーティングをitem_listsにネストしないよう変更
- タグの設定とバリデーションを変更
- i18n対応
- アイコンのサイズ変更
- もどるボタンの追加
- レイアウト調整